### PR TITLE
Extended wrp and put in empty events on failure to unmarshal/decrypt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 go:
   - 1.12.x
-  - tip
 
 os:
   - linux

--- a/primaryHandler.go
+++ b/primaryHandler.go
@@ -112,6 +112,8 @@ func (app *App) getDeviceInfo(deviceID string) ([]Event, error) {
 		if err != nil {
 			app.measures.DecryptFailure.Add(1.0)
 			logging.Error(app.logger).Log(logging.MessageKey(), "Failed to decode event", logging.ErrorKey(), err.Error())
+			// TODO: when we switch to wrp-go, change this to a constant
+			event.Type = 11
 			events = append(events, event)
 			continue
 		}
@@ -120,6 +122,8 @@ func (app *App) getDeviceInfo(deviceID string) ([]Event, error) {
 		if err != nil {
 			app.measures.UnmarshalFailure.Add(1.0)
 			logging.Error(app.logger).Log(logging.MessageKey(), "Failed to unmarshal decoded event", logging.ErrorKey(), err.Error())
+			// TODO: when we switch to wrp-go, change this to a constant
+			event.Type = 11
 			events = append(events, event)
 			continue
 		}

--- a/primaryHandler.go
+++ b/primaryHandler.go
@@ -21,10 +21,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Comcast/codex/blacklist"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/Comcast/codex/blacklist"
 
 	"github.com/Comcast/codex/cipher"
 
@@ -50,6 +51,11 @@ type App struct {
 	measures *Measures
 }
 
+type Event struct {
+	wrp.Message
+	BirthDate int64
+}
+
 // swagger:parameters getEvents getStatus
 type DeviceIdParam struct {
 	// device id passed by caller
@@ -64,7 +70,7 @@ type DeviceIdParam struct {
 // swagger:response EventResponse
 type EventResponse struct {
 	// in:body
-	Body []wrp.Message
+	Body []Event
 }
 
 // ErrResponse is the information passed to the client on an error
@@ -77,14 +83,14 @@ type ErrResponse struct {
 	Code int `json:"code"`
 }
 
-func (app *App) getDeviceInfo(deviceID string) ([]wrp.Message, error) {
+func (app *App) getDeviceInfo(deviceID string) ([]Event, error) {
 	if reason, ok := app.blacklist.InList(deviceID); ok {
-		return []wrp.Message{}, serverErr{errors.New(fmt.Sprintf("device in blacklist, reason: %s", reason)),
+		return []Event{}, serverErr{errors.New(fmt.Sprintf("device in blacklist, reason: %s", reason)),
 			http.StatusBadRequest}
 	}
 
 	records, hErr := app.eventGetter.GetRecords(deviceID, app.getLimit)
-	events := []wrp.Message{}
+	events := []Event{}
 
 	// if both have errors or are empty, return an error
 	if hErr != nil {
@@ -99,11 +105,14 @@ func (app *App) getDeviceInfo(deviceID string) ([]wrp.Message, error) {
 			continue
 		}
 
-		var event wrp.Message
+		event := Event{
+			BirthDate: record.BirthDate,
+		}
 		data, err := app.decrypter.DecryptMessage(record.Data, record.Nonce)
 		if err != nil {
 			app.measures.DecryptFailure.Add(1.0)
 			logging.Error(app.logger).Log(logging.MessageKey(), "Failed to decode event", logging.ErrorKey(), err.Error())
+			events = append(events, event)
 			continue
 		}
 
@@ -111,6 +120,7 @@ func (app *App) getDeviceInfo(deviceID string) ([]wrp.Message, error) {
 		if err != nil {
 			app.measures.UnmarshalFailure.Add(1.0)
 			logging.Error(app.logger).Log(logging.MessageKey(), "Failed to unmarshal decoded event", logging.ErrorKey(), err.Error())
+			events = append(events, event)
 			continue
 		}
 		events = append(events, event)
@@ -146,7 +156,7 @@ func (app *App) getDeviceInfo(deviceID string) ([]wrp.Message, error) {
  */
 func (app *App) handleGetEvents(writer http.ResponseWriter, request *http.Request) {
 	var (
-		d   []wrp.Message
+		d   []Event
 		err error
 	)
 	vars := mux.Vars(request)

--- a/primaryHandler_test.go
+++ b/primaryHandler_test.go
@@ -80,20 +80,20 @@ func TestGetDeviceInfo(t *testing.T) {
 		getRecordsErr         error
 		decryptErr            error
 		expectedFailureMetric float64
-		expectedEvents        []wrp.Message
+		expectedEvents        []Event
 		expectedErr           error
 		expectedStatus        int
 	}{
 		{
 			description:    "Get Records Error",
 			getRecordsErr:  getRecordsErr,
-			expectedEvents: []wrp.Message{},
+			expectedEvents: []Event{},
 			expectedErr:    getRecordsErr,
 			expectedStatus: http.StatusInternalServerError,
 		},
 		{
 			description:    "Empty Records Error",
-			expectedEvents: []wrp.Message{},
+			expectedEvents: []Event{},
 			expectedErr:    errors.New("No events found"),
 			expectedStatus: http.StatusNotFound,
 		},
@@ -104,7 +104,7 @@ func TestGetDeviceInfo(t *testing.T) {
 					DeathDate: previousTime,
 				},
 			},
-			expectedEvents: []wrp.Message{},
+			expectedEvents: []Event{},
 			expectedErr:    errors.New("No events found"),
 			expectedStatus: http.StatusNotFound,
 		},
@@ -117,9 +117,7 @@ func TestGetDeviceInfo(t *testing.T) {
 				},
 			},
 			expectedFailureMetric: 1.0,
-			expectedEvents:        []wrp.Message{},
-			expectedErr:           errors.New("No events found"),
-			expectedStatus:        http.StatusNotFound,
+			expectedEvents:        []Event{Event{}},
 		},
 		{
 			description: "Decrypt Error",
@@ -131,21 +129,20 @@ func TestGetDeviceInfo(t *testing.T) {
 				},
 			},
 			decryptErr:     errors.New("failed to decrypt"),
-			expectedEvents: []wrp.Message{},
-			expectedErr:    errors.New("No events found"),
-			expectedStatus: http.StatusNotFound,
+			expectedEvents: []Event{Event{}},
 		},
 		{
 			description: "Success",
 			recordsToReturn: []db.Record{
 				{
 					ID:        1234,
+					BirthDate: prevTime.Unix(),
 					DeathDate: futureTime,
 					Data:      goodData,
 				},
 			},
-			expectedEvents: []wrp.Message{
-				goodEvent,
+			expectedEvents: []Event{
+				Event{goodEvent, prevTime.Unix()},
 			},
 		},
 	}

--- a/primaryHandler_test.go
+++ b/primaryHandler_test.go
@@ -117,7 +117,7 @@ func TestGetDeviceInfo(t *testing.T) {
 				},
 			},
 			expectedFailureMetric: 1.0,
-			expectedEvents:        []Event{Event{}},
+			expectedEvents:        []Event{Event{wrp.Message{Type: 11}, 0}},
 		},
 		{
 			description: "Decrypt Error",
@@ -129,7 +129,7 @@ func TestGetDeviceInfo(t *testing.T) {
 				},
 			},
 			decryptErr:     errors.New("failed to decrypt"),
-			expectedEvents: []Event{Event{}},
+			expectedEvents: []Event{Event{wrp.Message{Type: 11}, 0}},
 		},
 		{
 			description: "Success",


### PR DESCRIPTION
fixes https://github.com/Comcast/codex/issues/51
~also does part of the work for https://github.com/Comcast/codex-gungnir/issues/52, since it's not yet known what the "unknown" wrp type will be.~
fixes https://github.com/Comcast/codex-gungnir/issues/52